### PR TITLE
Update dependencies

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,12 +9,13 @@
 #
 # docker run -i --rm -p 8081:8081 springboot/sample-demo
 ####
-FROM registry.access.redhat.com/ubi8/openjdk-21 AS builder
+FROM registry.access.redhat.com/ubi9/openjdk-21 AS builder
 
 # Build dependency offline to streamline build
 RUN mkdir project
 WORKDIR /home/jboss/project
 COPY pom.xml .
+USER root
 RUN mvn dependency:go-offline
 
 COPY src src
@@ -25,8 +26,7 @@ RUN grep version target/maven-archiver/pom.properties | cut -d '=' -f2 >.env-ver
 RUN grep artifactId target/maven-archiver/pom.properties | cut -d '=' -f2 >.env-id
 RUN mv target/$(cat .env-id)-$(cat .env-version).jar target/export-run-artifact.jar
 
-FROM registry.access.redhat.com/ubi8/openjdk-21-runtime
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime
 COPY --from=builder /home/jboss/project/target/export-run-artifact.jar  /deployments/export-run-artifact.jar
 EXPOSE 8081
 ENTRYPOINT ["/opt/jboss/container/java/run/run-java.sh", "--server.port=8081"]
-

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.3.6</version>
+		<version>3.4.4</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>


### PR DESCRIPTION
This commit updates the parent container images to the latest available UBI and OpenJDK versions. NOTE: With UBI9, the `mvn dependency:go-offline` command fails with a permission error. Adding `USER root` just before excecuting the command works around this limitation. This is ok, because the default `USER` is still used in the final build stage in the Dockerfile.

This commit also updates the version of spring-boot to address several security updates.

Ref: https://issues.redhat.com/browse/RHTAP-4793